### PR TITLE
Fix broken link

### DIFF
--- a/extra/ShareX.md
+++ b/extra/ShareX.md
@@ -52,7 +52,7 @@ If everything is OK you will see that and ShareX is ready to upload directly to 
 
 ## Upload images to an user account
 
-Chevereto API V1 works uploading images as guest. If you want to upload images to a given user check the [API user upload Workaround](./../api/V1.md).
+Chevereto API V1 works uploading images as guest. If you want to upload images to a given user check the [API user upload Workaround](./../API/V1.md).
 
 ## Need help?
 


### PR DESCRIPTION
The link [API user upload Workaround](https://v3-docs.chevereto.com/API/V1.html) is broken because "API" was written as lower case.